### PR TITLE
Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/.github/spellchecker-wordlist.txt
+++ b/.github/spellchecker-wordlist.txt
@@ -17,3 +17,15 @@ fatih
 dependabot
 ircs
 ssl
+TestArguments
+TestConfig
+TestFails
+golangci
+dockerignore
+Config
+struct
+Pre
+gitleaks
+golangci
+repo
+whitespace

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
-        go-version: 1.17
+        go-version: stable
 
     - name: Build
       run: go build -v ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,11 @@ The entire application logic lives in **`main.go`** (~410 lines) — there is no
 
 The three test suites in `main_test.go`:
 
-- **TestArguments** — exercises every CLI flag combination against the project's own directory; all expect exit code 0.
+- **TestArguments** — enumerates individual CLI flag cases against the project's own directory; these cases expect successful execution (exit code 0).
 - **TestFails** — creates temp directories with permission-restricted ignore files to trigger exit code 1.
-- **TestConfig** — validates config file loading with a temporary `.stevedore.json`.
+- **TestConfig** — exercises `realMain()` in the `tests/ok` fixture context after setting up `tests/ok/.dockerignore`; it does not currently create or validate loading a temporary `.stevedore.json`.
 
-Tests call `main()` directly via `os.Args` manipulation and capture behavior through exit codes. When adding new flags, add a corresponding case to `TestArguments`.
+Tests call `main()` directly via `os.Args` manipulation and capture behavior through exit codes. When adding new flags, consider adding or updating a focused case in `TestArguments`.
 
 ## Key Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**stevedore** is a Go CLI tool that analyzes a directory against a `.dockerignore` file, reporting which files will be included in or excluded from a Docker image. Named after dock workers who load/unload cargo.
+
+## Commands
+
+```bash
+# Build
+go build -v ./...
+
+# Test (all)
+go test -v ./...
+
+# Run a single test suite
+go test -v -run TestArguments
+go test -v -run TestFails
+go test -v -run TestConfig
+
+# Test with coverage
+go test -cover ./...
+
+# Lint
+golangci-lint run
+
+# Run the tool locally
+./stevedore .
+./stevedore --verbose .
+cat .dockerignore | ./stevedore --stdin
+```
+
+## Architecture
+
+The entire application logic lives in **`main.go`** (~410 lines) — there is no package split. Tests are in `main_test.go`.
+
+**Config struct** centralizes all options: color flags, output filters (`--included`, `--excluded`), path display (`--fullpath`), verbosity, and ignore file path. Configuration is layered:
+
+1. Global: `$XDG_CONFIG_HOME/stevedore/config.json` (fallback: `~/.config/stevedore/config.json`)
+2. Local: `.stevedore.json` in the working directory
+3. CLI flags (highest priority)
+
+**Core flow:**
+- Loads `.dockerignore` (or `--ignorefile` target) via `go-gitignore`
+- Optionally loads `.stevedoreignore` to filter the output listing itself
+- Walks the directory with `filepath.Walk()`
+- Matches each path against ignore patterns, accounting for directory trailing-slash semantics
+- Color-codes output: included files vs. excluded files
+
+**Exit codes:**
+- `0` — success
+- `1` — ignore file not found or unreadable
+- `2` — directory read error
+
+## Testing Patterns
+
+The three test suites in `main_test.go`:
+
+- **TestArguments** — exercises every CLI flag combination against the project's own directory; all expect exit code 0.
+- **TestFails** — creates temp directories with permission-restricted ignore files to trigger exit code 1.
+- **TestConfig** — validates config file loading with a temporary `.stevedore.json`.
+
+Tests call `main()` directly via `os.Args` manipulation and capture behavior through exit codes. When adding new flags, add a corresponding case to `TestArguments`.
+
+## Key Dependencies
+
+- `github.com/fatih/color` — terminal color output
+- `github.com/sabhiram/go-gitignore` — `.gitignore`/`.dockerignore` pattern matching
+
+## Pre-commit Hooks
+
+The repo uses `.pre-commit-config.yaml` with gitleaks (secret scanning), golangci-lint, end-of-file-fixer, and trailing-whitespace checks. Run `pre-commit run --all-files` before submitting changes if hooks are installed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-# Build
+# Build all packages (CI / compilation check)
 go build -v ./...
+
+# Build the local executable used below
+go build -o stevedore .
 
 # Test (all)
 go test -v ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Project Overview
 
-**stevedore** is a Go CLI tool that analyzes a directory against a `.dockerignore` file, reporting which files will be included in or excluded from a Docker image. Named after dock workers who load/unload cargo.
+**stevedore** is a Go CLI tool that analyzes a directory against a
+`.dockerignore` file, reporting which files will be included in or excluded
+from a Docker image. Named after dock workers who load/unload cargo.
 
 ## Commands
 
@@ -37,22 +40,29 @@ cat .dockerignore | ./stevedore --stdin
 
 ## Architecture
 
-The entire application logic lives in **`main.go`** (~410 lines) — there is no package split. Tests are in `main_test.go`.
+The entire application logic lives in **`main.go`** (~410 lines) — there is no
+package split. Tests are in `main_test.go`.
 
-**Config struct** centralizes all options: color flags, output filters (`--included`, `--excluded`), path display (`--fullpath`), verbosity, and ignore file path. Configuration is layered:
+**Config struct** centralizes all options: color flags, output filters
+(`--included`, `--excluded`), path display (`--fullpath`), verbosity, and
+ignore file path. Configuration is layered:
 
-1. Global: `$XDG_CONFIG_HOME/stevedore/config.json` (fallback: `~/.config/stevedore/config.json`)
+1. Global: `$XDG_CONFIG_HOME/stevedore/config.json`
+   (fallback: `~/.config/stevedore/config.json`)
 2. Local: `.stevedore.json` in the working directory
 3. CLI flags (highest priority)
 
 **Core flow:**
+
 - Loads `.dockerignore` (or `--ignorefile` target) via `go-gitignore`
 - Optionally loads `.stevedoreignore` to filter the output listing itself
 - Walks the directory with `filepath.Walk()`
-- Matches each path against ignore patterns, accounting for directory trailing-slash semantics
+- Matches each path against ignore patterns, accounting for directory
+  trailing-slash semantics
 - Color-codes output: included files vs. excluded files
 
 **Exit codes:**
+
 - `0` — success
 - `1` — ignore file not found or unreadable
 - `2` — directory read error
@@ -61,17 +71,27 @@ The entire application logic lives in **`main.go`** (~410 lines) — there is no
 
 The three test suites in `main_test.go`:
 
-- **TestArguments** — enumerates individual CLI flag cases against the project's own directory; these cases expect successful execution (exit code 0).
-- **TestFails** — creates temp directories with permission-restricted ignore files to trigger exit code 1.
-- **TestConfig** — exercises `realMain()` in the `tests/ok` fixture context after setting up `tests/ok/.dockerignore`; it does not currently create or validate loading a temporary `.stevedore.json`.
+- **TestArguments** — enumerates individual CLI flag cases against the
+  project's own directory; these cases expect successful execution (exit
+  code 0).
+- **TestFails** — creates temp directories with permission-restricted ignore
+  files to trigger exit code 1.
+- **TestConfig** — exercises `realMain()` in the `tests/ok` fixture context
+  after setting up `tests/ok/.dockerignore`; it does not currently create or
+  validate loading a temporary `.stevedore.json`.
 
-Tests call `main()` directly via `os.Args` manipulation and capture behavior through exit codes. When adding new flags, consider adding or updating a focused case in `TestArguments`.
+Tests call `main()` directly via `os.Args` manipulation and capture behavior
+through exit codes. When adding new flags, consider adding or updating a
+focused case in `TestArguments`.
 
 ## Key Dependencies
 
 - `github.com/fatih/color` — terminal color output
-- `github.com/sabhiram/go-gitignore` — `.gitignore`/`.dockerignore` pattern matching
+- `github.com/sabhiram/go-gitignore` — `.gitignore`/`.dockerignore` pattern
+  matching
 
 ## Pre-commit Hooks
 
-The repo uses `.pre-commit-config.yaml` with gitleaks (secret scanning), golangci-lint, end-of-file-fixer, and trailing-whitespace checks. Run `pre-commit run --all-files` before submitting changes if hooks are installed.
+The repo uses `.pre-commit-config.yaml` with gitleaks (secret scanning),
+golangci-lint, end-of-file-fixer, and trailing-whitespace checks. Run
+`pre-commit run --all-files` before submitting changes if hooks are installed.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root to guide future Claude Code sessions working in this repository
- Documents build, test, lint, and run commands (including how to run a single test suite)
- Describes the single-file architecture, layered config system, exit codes, and core `filepath.Walk` flow
- Explains the three test suites in `main_test.go` and the `os.Args` manipulation pattern used

## Test plan

- [ ] Verify commands listed in CLAUDE.md are accurate against the current codebase
- [ ] Confirm no sensitive information is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)