### PR TITLE
Fix go-releaser workflow: replace hardcoded Go 1.17 with stable

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -26,7 +26,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          go-version: 1.17
+          go-version: stable
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -26,7 +26,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          go-version: stable
+          go-version-file: go.mod
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1


### PR DESCRIPTION
## Summary

- `go-releaser.yml` hardcoded `go-version: 1.17`, which is incompatible with the module's `go 1.25.0` requirement in `go.mod` — any tag-triggered release build would fail
- Replaced with `go-version: stable`, consistent with `go-build.yml` which already uses this value

## Test plan

- [ ] Verify CI passes on this PR (`go-build.yml` runs on push to main but the releaser only triggers on tags — the compilation check in `go-build.yml` provides coverage)
- [ ] Confirm no other workflows reference a hardcoded Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)