### PR TITLE
Bump codeql-action init/autobuild/analyze to v4.36.3 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Dependabot opened three separate PRs (#261, #264, #265) that each bump one `github/codeql-action/*` sub-action from v4.36.2 to v4.36.3 independently.
- The `init` step stamps a config file with its pinned version, and `autobuild`/`analyze` refuse to run if their own version doesn't match that stamp. Merging any one of those PRs alone leaves the workflow with mismatched versions and breaks CI with:
  ```
  ##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
  CodeQL job status was configuration error.
  ```
- This PR bumps `init`, `autobuild`, and `analyze` to v4.36.3 together in `.github/workflows/codeql.yml`, using the same pinned SHA (`54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`) each of those PRs already proposed.
- #262 (`upload-sarif` bump) and #263 (`goreleaser-action` bump) are unaffected by this skew and can be merged independently.

## Test plan

- [x] CI (build, CodeQL go/ruby analyze, dependency-review) expected to pass now that all three CodeQL sub-actions are in sync.
- [ ] Close/supersede #261, #264, #265 once this PR merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01762hVYs9TiKxfG4oZpQetc)_