### PR TITLE
Add docs/TODO.md summarizing open GitHub issues

### DIFF
--- a/.github/spellchecker-wordlist.txt
+++ b/.github/spellchecker-wordlist.txt
@@ -29,3 +29,4 @@ gitleaks
 golangci
 repo
 whitespace
+ignorefile

--- a/.github/spellchecker-wordlist.txt
+++ b/.github/spellchecker-wordlist.txt
@@ -30,3 +30,4 @@ golangci
 repo
 whitespace
 ignorefile
+TODO

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,16 @@
+# TODO
+
+Open feature requests and enhancements tracked as GitHub issues on
+[jonasbn/stevedore](https://github.com/jonasbn/stevedore/issues).
+
+- [ ] [#4](https://github.com/jonasbn/stevedore/issues/4) — Proposed feature: interactive edit mode (`--edit` / `-e`)
+- [ ] [#6](https://github.com/jonasbn/stevedore/issues/6) — Proposed feature: output as tree structure (`--tree` / `-t`)
+- [ ] [#17](https://github.com/jonasbn/stevedore/issues/17) — Proposed feature: stacked ignore files (handle multiple ignore files together; reference implementation in [jonasbn/perl-app-yak](https://github.com/jonasbn/perl-app-yak))
+- [ ] [#18](https://github.com/jonasbn/stevedore/issues/18) — Option to optimize output for improved ignorefile artefacts
+- [ ] [#21](https://github.com/jonasbn/stevedore/issues/21) — Proposed feature: watch mode (continuously render the tree from #6 as `.dockerignore` changes)
+- [ ] [#24](https://github.com/jonasbn/stevedore/issues/24) — Evaluate parsing the ignore file so handled patterns can be marked
+- [ ] [#29](https://github.com/jonasbn/stevedore/issues/29) — Output as JSON for improved data handling
+
+## Not tracked here
+
+- [#2](https://github.com/jonasbn/stevedore/issues/2) — Renovate Dependency Dashboard (automated tracking issue, not actionable work)


### PR DESCRIPTION
## Summary

- Adds `docs/TODO.md` listing the 7 open enhancement issues (#4, #6, #17, #18, #21, #24, #29) as a checklist for quick reference.
- Notes the Renovate Dependency Dashboard (#2) separately since it's an automated tracking issue rather than actionable work.

## Test plan

- [x] Docs-only change, no code affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01762hVYs9TiKxfG4oZpQetc)_