### PR TITLE
Document CI gotchas and docs/ in CLAUDE.md

### DIFF
--- a/.github/spellchecker-wordlist.txt
+++ b/.github/spellchecker-wordlist.txt
@@ -31,3 +31,12 @@ repo
 whitespace
 ignorefile
 TODO
+CodeQL
+codeql
+yml
+PRs
+OSSF
+autobuild
+init
+wordlist
+Markdownlint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,38 @@ focused case in `TestArguments`.
 - `github.com/sabhiram/go-gitignore` — `.gitignore`/`.dockerignore` pattern
   matching
 
+## CI / GitHub Actions
+
+Workflows live under `.github/workflows/`:
+
+- **build** — `go build`/`go test` on push and PR.
+- **codeql.yml** — CodeQL analysis (go, ruby). The `init`, `autobuild`, and
+  `analyze` steps must all be pinned to the *same* `codeql-action` version.
+  Dependabot bumps these as separate PRs, one per sub-action; merging just
+  one alone leaves the others behind and breaks CI with `Loaded a
+  configuration file for version X, but running version Y`. Bump `init`,
+  `autobuild`, and `analyze` together (consolidate the Dependabot PRs into
+  one branch/PR) rather than merging them individually.
+- **scorecard.yml** — OSSF Scorecard; uses `codeql-action/upload-sarif`,
+  which is independent of the init/autobuild/analyze version-sync
+  constraint above and can be bumped on its own.
+- **Spellcheck** — `rojopolis/spellcheck-github-actions`, config at
+  `.github/spellcheck.yml`, checks all `**/*.md` files (including headings)
+  against `.github/spellchecker-wordlist.txt`. Adding a doc with a
+  project-specific term or an all-caps heading (e.g. `TODO`) that isn't a
+  dictionary word requires adding it to the wordlist or the job fails.
+- **Markdownlint** — lints all Markdown files.
+- **dependency-review** — runs on PRs that change dependencies.
+- Copilot's automated PR reviewer and the Coveralls coverage bot both
+  comment on PRs automatically; check for these before assuming a human
+  reviewer commented.
+
+## Documentation
+
+- `docs/TODO.md` — checklist mirroring the open GitHub enhancement issues.
+  Keep it in sync (add/check off entries) when issues are opened or closed,
+  if asked to.
+
 ## Pre-commit Hooks
 
 The repo uses `.pre-commit-config.yaml` with gitleaks (secret scanning),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ focused case in `TestArguments`.
 
 Workflows live under `.github/workflows/`:
 
-- **build** — `go build`/`go test` on push and PR.
+- **go-build.yml** ("Go Build and Test Action") — `go build`/`go test` on push and PR.
 - **codeql.yml** — CodeQL analysis (go, ruby). The `init`, `autobuild`, and
   `analyze` steps must all be pinned to the *same* `codeql-action` version.
   Dependabot bumps these as separate PRs, one per sub-action; merging just
@@ -105,13 +105,14 @@ Workflows live under `.github/workflows/`:
 - **scorecard.yml** — OSSF Scorecard; uses `codeql-action/upload-sarif`,
   which is independent of the init/autobuild/analyze version-sync
   constraint above and can be bumped on its own.
-- **Spellcheck** — `rojopolis/spellcheck-github-actions`, config at
-  `.github/spellcheck.yml`, checks all `**/*.md` files (including headings)
-  against `.github/spellchecker-wordlist.txt`. Adding a doc with a
+- **check-spelling.yml** ("Spellcheck Action") — `rojopolis/spellcheck-github-actions`,
+  config at `.github/spellcheck.yml`, checks all `**/*.md` files (including
+  headings) against `.github/spellchecker-wordlist.txt`. Adding a doc with a
   project-specific term or an all-caps heading (e.g. `TODO`) that isn't a
   dictionary word requires adding it to the wordlist or the job fails.
-- **Markdownlint** — lints all Markdown files.
-- **dependency-review** — runs on PRs that change dependencies.
+- **markdownlint.yml** ("Markdownlint Action") — lints all Markdown files.
+- **dependency-review.yml** ("Dependency Review") — runs on every PR, scanning
+  dependency manifest changes introduced by that PR.
 - Copilot's automated PR reviewer and the Coveralls coverage bot both
   comment on PRs automatically; check for these before assuming a human
   reviewer commented.


### PR DESCRIPTION
## Summary

- Adds a "CI / GitHub Actions" section to `CLAUDE.md` documenting:
  - The `codeql-action` `init`/`autobuild`/`analyze` version-sync constraint: Dependabot bumps these as separate PRs, and merging just one alone breaks CI with a `Loaded a configuration file for version X, but running version Y` error (root cause of the earlier #261/#264/#265 CI failures, fixed together in #266).
  - The Spellcheck job (`rojopolis/spellcheck-github-actions`), which checks Markdown headings too, so new docs need entries in `.github/spellchecker-wordlist.txt` (hit while adding `docs/TODO.md` in #267).
  - That Copilot's automated PR reviewer and the Coveralls bot comment on PRs automatically.
- Adds a short "Documentation" section noting `docs/TODO.md` should stay in sync with open issues.

## Test plan

- [x] Docs-only change, no code affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01762hVYs9TiKxfG4oZpQetc)_