### PR TITLE
Add persist-credentials: false to workflow checkout steps

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Check out repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Spellcheck
       uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,8 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Check out repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Check out repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Markdownlint
       uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1 # v3.5.0


### PR DESCRIPTION
## Summary
- Sets `persist-credentials: false` on the `actions/checkout` step in `check-spelling.yml`, `dependency-review.yml`, `go-build.yml`, and `markdownlint.yml`, so the GitHub token isn't persisted in the local git config for jobs that don't need to push.
- Same change as commit b647032, which landed directly on `main`; that commit was reverted (48e1719) and is resubmitted here to go through PR review.

## Test plan
- [ ] CI green