### PR TITLE
Bump codeql-action init/autobuild/analyze to v4.37.1 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- Consolidates #278 (init → 4.37.1), #277 (autobuild → 4.37.1), and #280 (analyze → 4.37.1) so all three codeql-action steps in `codeql.yml` stay on the same version.
- Mirrors the pattern used in #274 for the v4.37.0 sync.
- Closes #278, closes #277, closes #280.
- `upload-sarif` (#276) uses codeql-action independently in `scorecard.yml` and is not affected by this version-sync constraint, so it's left out and can be merged on its own.

## Test plan
- [x] CI green (Analyze go/ruby jobs, which would fail on #277/#278/#280 individually due to version mismatch)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDNRzwenhzsnpX7VGzWsxc)_