### PR TITLE
Bump codeql-action init/autobuild/analyze to v4.37.3 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- Consolidates dependabot PRs #282, #284, and #286, each of which bumped one of the three `codeql-action` sub-actions (`autobuild`, `analyze`, `init`) individually from v4.37.1 to v4.37.3
- `init`, `autobuild`, and `analyze` must stay pinned to the same `codeql-action` version, or CI breaks with `Loaded a configuration file for version X, but running version Y`
- This mirrors the approach previously taken in #281 for the v4.37.1 bump

## Test plan
- [x] CI (`Go Build and Test Action`, CodeQL analysis) runs on this PR
- [ ] Close #282, #284, #286 as superseded once this merges


---
_Generated by [Claude Code](https://claude.ai/code/session_01QqTSGdhB33skr5yndVwQnN)_