### PR TITLE
Add zizmor GitHub Actions security scanning workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
       security-events: write
 
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,46 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  ZIZMOR_VERSION: 1.28.0
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Run zizmor
+        run: uvx "zizmor@${ZIZMOR_VERSION}" --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/zizmor.yml`, running [zizmor](https://github.com/zizmorcore/zizmor) (a static analysis tool for GitHub Actions workflows) against `.github/workflows` on push/PR to `main`
- Uploads SARIF findings to the repo's code-scanning dashboard, alongside CodeQL and Scorecard
- Follows this repo's existing workflow conventions: Harden Runner first, all third-party actions pinned to commit SHA with version comment, `persist-credentials: false` on checkout

## Why
zizmor catches classes of GitHub Actions-specific issues (script/template injection via untrusted event data, overly broad `permissions:`, unpinned actions) that CodeQL and Scorecard don't check for.

## Test plan
- [ ] Confirm the workflow runs successfully on this PR and SARIF results appear under the Security > Code scanning tab
- [ ] Confirm no findings are reported against the existing workflows (or triage any that are)