### PR TITLE
Fix zizmor findings: artipacked, cache-poisoning, dependabot-cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,20 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "gomod"
     # Look for Go code in the `root` directory
@@ -13,8 +27,26 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -22,11 +22,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          cache: false
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3


### PR DESCRIPTION
## Summary
Follow-up to #288, which merged before this fix commit was pushed to the branch — the zizmor workflow landed on `main`, but these fixes for the findings it reported did not.

- `codeql.yml`, `go-releaser.yml`: set `persist-credentials: false` on checkout (artipacked)
- `go-releaser.yml`: disable `setup-go`'s default caching (cache-poisoning)
- `dependabot.yml`: add 7-day cooldown + minor/patch grouping to all three ecosystems (dependabot-cooldown)

## Test plan
- [ ] Confirm zizmor CI passes on this PR
- [ ] Confirm code-scanning alerts #40-45 (zizmor/dependabot-cooldown x3, zizmor/artipacked x2, zizmor/cache-poisoning x1) auto-close after merge